### PR TITLE
Filter out assets that are not files

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,77 +9,94 @@
 'use strict';
 
 var glob = require('glob'),
-	_ = require('underscore');
+  fs = require('fs'),
+  _ = require('underscore');
 
 // Asset holder variable
 var assets = {
-	css: [],
-	js: []
+  css: [],
+  js: []
 };
 
 exports.init = function (options) {
-	// Glob options
-	var globOptions = {sync: true};
+  // Glob options
+  var globOptions = {sync: true};
 
-	options = _.extend({
-		css: {},
-		js: {},
-		debug: true,
-		webroot: false
-	}, options);
+  options = _.extend({
+    css: {},
+    js: {},
+    debug: true,
+    webroot: false
+  }, options);
 
-	// Get CSS
-	_.each(options.css, function (value, key) {
-		if (!options.debug) {
-			assets.css.push(key);
-			return;
-		}
-		if (_.isArray(value)) {
-			_.each(value, function (path) {
-				glob(path, globOptions, function (er, files) {
-					assets.css = assets.css.concat(files);
-				});
-			});
-		} else if (_.isString(value)) {
-			glob(value, globOptions, function (er, files) {
-				assets.css = assets.css.concat(files);
-			});
-		}
-	});
-	// Get JavaScript
-	_.each(options.js, function (value, key) {
-		if (!options.debug) {
-			assets.js.push(key);
-			return;
-		}
-		if (_.isArray(value)) {
-			_.each(value, function (path) {
-				glob(path, globOptions, function (er, files) {
-					assets.js = assets.js.concat(files);
-				});
-			});
-		} else if (_.isString(value)) {
-			glob(value, globOptions, function (er, files) {
-				assets.js = assets.js.concat(files);
-			});
-			var regex = new RegExp('^(http://|https://|//)');
-			if (value.match(regex).length > 0) {
-				// Source is external
-				assets.js.push(value);
-			}
-		}
-	});
+  /**
+   * Filter out assets that are not files
+   *
+   * @param files
+   */
+  var filterFiles = function (files) {
+    return _.filter(files, function (file) {
+      return fs.statSync(file).isFile();
+    });
+  };
 
-	if (options.webroot) {
-		// Strip the webroot foldername from the filepath
-		var regex = new RegExp('^' + options.webroot);
-		_.each(assets.css, function (value, key) {
-			assets.css[key] = value.replace(regex, '');
-		});
-		_.each(assets.js, function (value, key) {
-			assets.js[key] = value.replace(regex, '');
-		});
-	}
+  /**
+   * Get assets from pattern. Pattern could be
+   *  - an array
+   *  - a string
+   *  - external resource
+   *
+   * @param pattern
+   */
+  var getAssets = function (pattern) {
+    var files = [];
+    if (_.isArray(pattern)) {
+      _.each(pattern, function (path) {
+        files = files.concat(getAssets(path));
+      });
+    } else if (_.isString(pattern)) {
+      var regex = new RegExp('^(http://|https://|//)');
+      if (regex.test(pattern)) {
+        // Source is external
+        files.push(pattern);
+      } else {
+        glob(pattern, globOptions, function (er, matches) {
+          files = filterFiles(matches);
+        });
+      }
+    }
+
+    return files;
+  }
+
+  // Get CSS
+  _.each(options.css, function (value, key) {
+    if (!options.debug) {
+      assets.css.push(key);
+    } else {
+      assets.css = assets.css.concat(getAssets(value));
+    }
+  });
+
+  // Get JavaScript
+  _.each(options.js, function (value, key) {
+    if (!options.debug) {
+      assets.js.push(key);
+    } else {
+      assets.js = assets.js.concat(getAssets(value));
+    }
+  });
+
+  if (options.webroot) {
+    // Strip the webroot foldername from the filepath
+    var regex = new RegExp('^' + options.webroot);
+    _.each(assets.css, function (value, key) {
+      assets.css[key] = value.replace(regex, '');
+    });
+    _.each(assets.js, function (value, key) {
+      assets.js[key] = value.replace(regex, '');
+    });
+  }
 };
 
 exports.assets = assets;


### PR DESCRIPTION
This PR does 2 things:
- Filter out assets that are not files. I have a case when a folder contains a dot (.) in its name, let's say video.js folder inside public/system/lib folder. Therefore, a pattern likes: "public/*/*/*.js" in assets.json will return public/system/lib/video.js/, which will cause a 404 since it's not actually a file.
- Refactoring your code and allow external css to be included in asset. Previously, you only handled the case of js
