### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ results
 
 npm-debug.log
 node_modules
+coverage
 
 .idea/

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@
 
 var grunt = require('grunt'),
 	crypto = require('crypto'),
-	_ = require('underscore');
+	_ = require('lodash');
 
 /**
  * Checks that `resource` is an external URL.
@@ -88,7 +88,7 @@ exports.process = function (options) {
 			if (!isExternal(file))
 				hash.update(grunt.file.read(file), 'utf-8');
 		});
-    return hash.digest('hex');
+    	return hash.digest('hex');
 	};
 
 	// Core logic to format assets

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/ReedD/node-assetmanager",
   "dependencies": {
-    "grunt": "^0.4.5",
-    "underscore": "^1.6.0"
+    "grunt": "^1.0.1",
+    "lodash": "^4.11.0"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
Grunt exists in version 1.x from now on and I recommend to switch to lodash. It is in most cases faster than underscore and as far as I know they work together anyway. They mainly have the same API, especially for the limited features used in the assetmanager.